### PR TITLE
feat: Encoder harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Features
+
+- Encoder harness
+
 #### Breaking Changes
 
 - Fixed the naming of `Encoded` to `Decoded`


### PR DESCRIPTION
We aren't yet included a default fixture, which is why the CLI is
untouched.  This is a step towards getting a potential a compliant
fixture released (toml_edit).