### PR TITLE
chore: update libtest-mimic to 0.4.0

### DIFF
--- a/crates/harness/Cargo.toml
+++ b/crates/harness/Cargo.toml
@@ -20,4 +20,4 @@ include = [
 toml-test-data = { version = "1.0", path = "../data" }
 toml-test = { version = "^0.3", path = "../../" }
 ignore = "0.4"
-libtest-mimic = "0.3.0"
+libtest-mimic = "0.4.0"


### PR DESCRIPTION
This allows toml-test-rs to work with cargo-nextest.